### PR TITLE
docs: update repository URLs from spreadsheet-llm to csvalchemy-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ We welcome contributions from the community! This guide will help you set up you
 1. **Fork and Clone the Repository**
 
    ```bash
-   git clone https://github.com/Unsiloed-ai/spreadsheet-llm.git
-   cd spreadsheet-llm
+   git clone https://github.com/Unsiloed-ai/csvalchemy-sdk.git
+   cd csvalchemy-sdk
    ```
 
 2. **Set Up a Virtual Environment**
@@ -160,7 +160,7 @@ We welcome contributions from the community! This guide will help you set up you
 
 6. **Create a Pull Request**
    
-   Go to the [original repository](https://github.com/Unsiloed-AI/spreadsheet-llm) and create a pull request from your fork.
+   Go to the [original repository](https://github.com/Unsiloed-AI/csvalchemy-sdk) and create a pull request from your fork.
 
 ### Code Style Guidelines
 


### PR DESCRIPTION
This PR fixes all instances of the invalid repository URL (`spreadsheet-llm`) in the README to point to the new repository name (`csvalchemy-sdk`).

Changes made:
- Updated all references to `https://github.com/Unsiloed-ai/spreadsheet-llm.git`
- Replaced with `https://github.com/Unsiloed-ai/csvalchemy-sdk`

This ensures:
- Correct cloning instructions for new contributors
- Proper links to repository resources
- Consistency across documentation